### PR TITLE
Add thread-through state to all partitions

### DIFF
--- a/src/analysis/ipoincidence.jl
+++ b/src/analysis/ipoincidence.jl
@@ -105,7 +105,6 @@ function apply_linear_incidence(𝕃, ret::PartialStruct, caller::CallerMappingS
     return PartialStruct(𝕃, ret.typ, Any[apply_linear_incidence(𝕃, f, caller, mapping) for f in ret.fields])
 end
 
-
 function process_template!(𝕃, coeffs, eq_mapping, applied_scopes, argtypes, template_argtypes)
     for (arg, template) in zip(argtypes, template_argtypes)
         if isa(template, Incidence)

--- a/src/transform/autodiff/index_lowering.jl
+++ b/src/transform/autodiff/index_lowering.jl
@@ -72,7 +72,7 @@ function index_lowering_ad!(state::TransformationState, key::TornCacheKey)
     # Mark all non-trivial `ddt()` statements as ones that we should differentiate
     diff_ssas = Pair{SSAValue,Int}[]
     for i = 1:length(ir.stmts)
-        if is_known_invoke(ir.stmts[i][:stmt], ddt, ir) && !is_const_plus_state_linear(argextype(ir.stmts[i][:stmt].args[end], ir), key.param_vars)
+        if is_known_invoke(ir.stmts[i][:stmt], ddt, ir) && !is_const_plus_var_linear(argextype(ir.stmts[i][:stmt].args[end], ir))
             push!(diff_ssas, SSAValue(i) => 0)
         end
     end

--- a/src/transform/codegen/init_factory.jl
+++ b/src/transform/codegen/init_factory.jl
@@ -25,10 +25,9 @@ function init_uncompress_gen!(compact::Compiler.IncrementalCompact, result::DAEI
         @assert sicm_ci !== nothing
 
         line = result.ir[SSAValue(1)][:line]
-        #insert_node_here!(compact, NewInstruction(Expr(:call, println, "Trace: A"), Cvoid, line))
+        param_list = flatten_parameter!(compact, result.ir.argtypes[1:end], argn->Argument(2+argn), line)
         sicm = insert_node_here!(compact,
-            NewInstruction(Expr(:call, invoke, Argument(3), sicm_ci, (Argument(i+1) for i = 2:length(result.ir.argtypes))...), Tuple, line))
-        #insert_node_here!(compact, NewInstruction(Expr(:call, println, "Trace: B"), Cvoid, line))
+            NewInstruction(Expr(:call, invoke, param_list, sicm_ci), Tuple, line))
     else
         sicm = ()
     end
@@ -76,7 +75,7 @@ function init_uncompress_gen!(compact::Compiler.IncrementalCompact, result::DAEI
     ntotalstates = numstates[AssignedDiff] + numstates[UnassignedDiff] + numstates[Algebraic]
 
     (out_u_mm, out_u_unassgn, out_alg) = sciml_dae_split_u!(oc_compact, line, out_arr, numstates)
-    (out_du_unassgn, _) = sciml_dae_split_du!(oc_compact, line, scratch_arr, numstates) 
+    (out_du_unassgn, _) = sciml_dae_split_du!(oc_compact, line, scratch_arr, numstates)
 
     # Call DAECompiler-generated RHS with internal ABI
     oc_sicm = insert_node_here!(oc_compact,

--- a/src/transform/codegen/ode_factory.jl
+++ b/src/transform/codegen/ode_factory.jl
@@ -70,7 +70,9 @@ function ode_factory_gen(state::TransformationState, ci::CodeInstance, key::Torn
         @assert sicm_ci !== nothing
 
         line = result.ir[SSAValue(1)][:line]
-        sicm = @insert_node_here compact line invoke(Argument(3), sicm_ci, (Argument(i+1) for i = 2:length(result.ir.argtypes))...)::Tuple
+        param_list = flatten_parameter!(compact, result.ir.argtypes[1:end], argn->Argument(2+argn), line)
+        sicm = insert_node_here!(compact,
+            NewInstruction(Expr(:call, invoke, param_list, sicm_ci), Tuple, line))
     else
         sicm = ()
     end

--- a/test/ipo.jl
+++ b/test/ipo.jl
@@ -139,4 +139,21 @@ for sol in (dae_sol, ode_sol)
     @test all(map((x,y)->isapprox(x[], y, atol=1e-2), sol[1, :], 1 .+ sol.t))
 end
 
+#========== Structured SICM ===========#
+@noinline function add4((a, b, c, d)::NTuple{4, Float64})
+    always!((a + b) + (c + d))
+end
+
+function structured_sicm()
+    x = continuous()
+    add4((1., 2., ddt(x), -x))
+end
+
+dae_sol = solve(DAECProblem(structured_sicm, (1,) .=> 1), IDA())
+ode_sol = solve(ODECProblem(structured_sicm, (1,) .=> 1), Rodas5(autodiff=false))
+
+for sol in (dae_sol, ode_sol)
+    @test all(map((x,y)->isapprox(x[], y, atol=1e-2), sol[1, :], 3 .- 2exp.(sol.t)))
+end
+
 end


### PR DESCRIPTION
This changes the ABI of our scheduled functions to return tuples of the requested equation residuals and some thread-through state (these are basically the same as the optic residuals in Diffractor, but I'm avoiding using the terms residuals, because that already has three meanings in DAECompiler). This temporarily somewhat regresses SICM quality, but we need to do some further work to properly integrate SICM with our initialization system, and I'd like to wait with restoring SICM quality until that is done.