### PR TITLE
Normalize nested argument lists early

### DIFF
--- a/src/DAECompiler.jl
+++ b/src/DAECompiler.jl
@@ -23,6 +23,7 @@ module DAECompiler
     include("analysis/refiner.jl")
     include("analysis/ipoincidence.jl")
     include("analysis/structural.jl")
+    include("analysis/flattening.jl")
     include("transform/state_selection.jl")
     include("transform/common.jl")
     include("transform/runtime.jl")

--- a/src/analysis/cache.jl
+++ b/src/analysis/cache.jl
@@ -21,6 +21,15 @@ end
     var_schedule::Vector{Pair{BitSet, BitSet}}
 end
 
+"""
+    StructuralSSARef
+
+Represents an SSA reference to the IR after structural analysis. Used as keys for callees, etc.
+"""
+struct StructuralSSARef
+    id::Int
+end
+
 struct DAEIPOResult
     ir::IRCode
     extended_rt::Any
@@ -34,7 +43,7 @@ struct DAEIPOResult
     varclassification::Vector{VarEqClassification}
     total_incidence::Vector{Any}
     eqclassification::Vector{VarEqClassification}
-    eq_callee_mapping::Vector{Union{Nothing, Vector{Pair{SSAValue, Int}}}}
+    eq_callee_mapping::Vector{Union{Nothing, Vector{Pair{StructuralSSARef, Int}}}}
     names::OrderedDict{Any, ScopeDictEntry} # TODO: OrderedIdDict
     varkinds::Vector{Union{Intrinsics.VarKind, Nothing}}
     eqkinds::Vector{Union{Intrinsics.EqKind, Nothing}}

--- a/src/analysis/consistency.jl
+++ b/src/analysis/consistency.jl
@@ -27,7 +27,7 @@ function get_inline_backtrace(ir::IRCode, v::SSAValue)
     runtime_jl_path = maybe_realpath(joinpath(dirname(pathof(@__MODULE__)), "runtime.jl"))
 
     frames = Base.StackTrace();
-    for lineinfo in Base.IRShow.buildLineInfoNode(ir.debuginfo, nothing, v.id)
+    for lineinfo in Compiler.IRShow.buildLineInfoNode(ir.debuginfo, nothing, v.id)
         btpath = maybe_realpath(expanduser(string(lineinfo.file)))
         if btpath != runtime_jl_path
             frame = Base.StackFrame(lineinfo.method, lineinfo.file, lineinfo.line)

--- a/src/analysis/flattening.jl
+++ b/src/analysis/flattening.jl
@@ -1,0 +1,99 @@
+# TODO: We should unify this function with _make_argument_lattice_elem to ensure consistency
+function _flatten_parameter!(𝕃, compact, argtypes, ntharg, line)
+    list = Any[]
+    for (argn, argt) in enumerate(argtypes)
+        if isa(argt, Const)
+            continue
+        elseif Base.issingletontype(argt)
+            continue
+        elseif Base.isprimitivetype(argt) || isa(argt, Incidence)
+            push!(list, ntharg(argn))
+        elseif isa(argt, Type) && argt <: Intrinsics.AbstractScope
+            continue
+        elseif isabstracttype(argt) || ismutabletype(argt) || (!isa(argt, DataType) && !isa(argt, PartialStruct))
+            continue
+        else
+            if !isa(argt, PartialStruct) && Base.datatype_fieldcount(argt) === nothing
+                continue
+            end
+            this = ntharg(argn)
+            nthfield(i) = insert_node_here!(compact,
+                NewInstruction(Expr(:call, getfield, this, i), Compiler.getfield_tfunc(𝕃, argextype(this, compact), Const(i)), line))
+            if isa(argt, PartialStruct)
+                fields = _flatten_parameter!(𝕃, compact, argt.fields, nthfield, line)
+            else
+                fields = _flatten_parameter!(𝕃, compact, fieldtypes(argt), nthfield, line)
+            end
+            append!(list, fields)
+        end
+    end
+    return list
+end
+
+function flatten_parameter!(𝕃, compact, argtypes, ntharg, line)
+    return insert_node_here!(compact,
+        NewInstruction(Expr(:call, tuple, _flatten_parameter!(𝕃, compact, argtypes, ntharg, line)...), Tuple, line))
+end
+
+# Needs to match flatten_arguments!
+function process_template_arg!(𝕃, coeffs, eq_mapping, applied_scopes, argt, template_argt, offset=0)
+    if isa(template_argt, Const)
+        @assert isa(argt, Const) && argt.val === template_argt.val
+        return offset
+    elseif Base.issingletontype(template_argt)
+        @assert isa(template_argt, Type) && argt.instance === template_argt.instance
+        return offset
+    elseif Base.isprimitivetype(template_argt)
+        coeffs[offset+1] = argt
+        return offset + 1
+    elseif isabstracttype(template_argt) || ismutabletype(template_argt) || (!isa(template_argt, DataType) && !isa(template_argt, PartialStruct))
+        return offset
+    else
+        if !isa(template_argt, PartialStruct) && Base.datatype_fieldcount(template_argt) === nothing
+            return offset
+        end
+        template_fields = isa(template_argt, PartialStruct) ? template_argt.fields : collect(fieldtypes(template_argt))
+        return process_template!(𝕃, coeffs, eq_mapping, applied_scopes, Any[Compiler.getfield_tfunc(𝕃, argt, Const(i)) for i = 1:length(template_fields)], template_fields, offset)
+    end
+end
+
+function process_template!(𝕃, coeffs, eq_mapping, applied_scopes, argtypes, template_argtypes, offset=0)
+    @assert length(argtypes) == length(template_argtypes)
+    for (i, template_arg) in enumerate(template_argtypes)
+        offset = process_template_arg!(𝕃, coeffs, eq_mapping, applied_scopes, argtypes[i], template_arg, offset)
+    end
+    return offset
+end
+
+function flatten_argument!(compact::Compiler.IncrementalCompact, argt, offset, argtypes::Vector{Any})::Pair{Any, Int}
+    @assert !isa(argt, Incidence)
+    if isa(argt, Const)
+        return Pair{Any, Int}(argt.val, offset)
+    elseif Base.issingletontype(argt)
+        return Pair{Any, Int}(argt.instance, offset)
+    elseif Base.isprimitivetype(argt)
+        push!(argtypes, argt)
+        return Pair{Any, Int}(Argument(offset+1), offset+1)
+    elseif isabstracttype(argt) || ismutabletype(argt) || (!isa(argt, DataType) && !isa(argt, PartialStruct))
+        ssa = insert_node_here!(compact, NewInstruction(Expr(:call, error, "Cannot IPO model arg type $argt"), Union{}, compact[Compiler.OldSSAValue(1)][:line]))
+        return Pair{Any, Int}(ssa, offset)
+    else
+        if !isa(argt, PartialStruct) && Base.datatype_fieldcount(argt) === nothing
+            ssa = insert_node_here!(compact, NewInstruction(Expr(:call, error, "Cannot IPO model arg type $argt"), Union{}, compact[Compiler.OldSSAValue(1)][:line]))
+            return Pair{Any, Int}(ssa, offset)
+        end
+        (args, _, offset) = flatten_arguments!(compact, isa(argt, PartialStruct) ? argt.fields : fieldtypes(argt), offset, argtypes)
+        this = Expr(:new, isa(argt, PartialStruct) ? argt.typ : argt, args...)
+        ssa = insert_node_here!(compact, NewInstruction(this, argt, compact[Compiler.OldSSAValue(1)][:line]))
+        return Pair{Any, Int}(ssa, offset)
+    end
+end
+
+function flatten_arguments!(compact::Compiler.IncrementalCompact, argtypes, offset=0, new_argtypes::Vector{Any} = Any[])
+    args = Any[]
+    for argt in argtypes
+        (ssa, offset) = flatten_argument!(compact, argt, offset, new_argtypes)
+        push!(args, ssa)
+    end
+    return (args, new_argtypes, offset)
+end

--- a/src/analysis/ipoincidence.jl
+++ b/src/analysis/ipoincidence.jl
@@ -105,54 +105,12 @@ function apply_linear_incidence(𝕃, ret::PartialStruct, caller::CallerMappingS
     return PartialStruct(𝕃, ret.typ, Any[apply_linear_incidence(𝕃, f, caller, mapping) for f in ret.fields])
 end
 
-function process_template!(𝕃, coeffs, eq_mapping, applied_scopes, argtypes, template_argtypes)
-    for (arg, template) in zip(argtypes, template_argtypes)
-        if isa(template, Incidence)
-            if isempty(template)
-                # @assert iszero(arg)
-                continue
-            end
-            (idxs, vals) = findnz(template.row)
-            @assert only(vals) == 1.0
-            @assert !isassigned(coeffs, only(idxs)-1)
-            coeffs[only(idxs)-1] = arg
-        elseif isa(template, Eq)
-            @assert isa(arg, Eq)
-            eq_mapping[idnum(template)] = idnum(arg)
-        elseif Compiler.is_const_argtype(template)
-            #@CC.show (arg, template)
-            #@assert CC.is_lattice_equal(DAE_LATTICE, arg, template)
-        elseif isa(template, PartialScope)
-            id = idnum(template)
-            (id > length(applied_scopes)) && resize!(applied_scopes, id)
-            if isa(arg, Const)
-                @assert isa(arg.val, Union{Scope, Nothing})
-                applied_scopes[id] = arg.val
-            elseif isa(arg, PartialScope)
-                applied_scopes[id] = arg
-            else
-                applied_scopes[id] = arg
-            end
-        elseif isa(template, PartialStruct)
-            if isa(arg, PartialStruct)
-                fields = arg.fields
-            else
-                fields = Any[Compiler.getfield_tfunc(𝕃, arg, Const(i)) for i = 1:length(template.fields)]
-            end
-            process_template!(𝕃, coeffs, eq_mapping, applied_scopes, fields, template.fields)
-        else
-            @show (arg, template, template_argtypes)
-            error()
-        end
-    end
-end
-
-function CalleeMapping(𝕃::Compiler.AbstractLattice, argtypes::Vector{Any}, callee_result::DAEIPOResult)
+function CalleeMapping(𝕃::Compiler.AbstractLattice, argtypes::Vector{Any}, callee_result::DAEIPOResult, template_argtypes)
     applied_scopes = Any[]
     coeffs = Vector{Any}(undef, length(callee_result.var_to_diff))
     eq_mapping = fill(0, length(callee_result.total_incidence))
 
-    process_template!(𝕃, coeffs, eq_mapping, applied_scopes, argtypes, callee_result.argtypes)
+    process_template!(𝕃, coeffs, eq_mapping, applied_scopes, argtypes, template_argtypes)
 
     return CalleeMapping(coeffs, eq_mapping, applied_scopes)
 end

--- a/src/analysis/lattice.jl
+++ b/src/analysis/lattice.jl
@@ -109,7 +109,7 @@ struct Incidence
     typ::Union{Type, Const}
     row::IncidenceVector
 
-    function Incidence(@nospecialize(type), row)
+    function Incidence(@nospecialize(type), row::AbstractVector)
         if is_non_incidence_type(type)
             throw(DomainError(type, "Invalid type for Incidence"))
         end
@@ -197,6 +197,12 @@ function Incidence(v::Int)
     row = _zero_row()
     row[v+1] = 1.0
     return Incidence(_ZERO_CONST, row)
+end
+function Incidence(T::Union{Type, Compiler.Const}, v::Int)
+    T === Float64 && return Incidence(v)
+    row = _zero_row()
+    row[v+1] = nonlinear
+    return Incidence(T, row)
 end
 
 "Identify the id number of an equation or variable"

--- a/src/analysis/refiner.jl
+++ b/src/analysis/refiner.jl
@@ -57,7 +57,9 @@ Compiler.cache_owner(::StructuralRefiner) = StructureCache()
     end
 
     argtypes = Compiler.collect_argtypes(interp, stmt.args, Compiler.StatementState(nothing, false), irsv)[2:end]
-    mapping = CalleeMapping(Compiler.optimizer_lattice(interp), argtypes, callee_result)
+    m = Compiler.get_ci_mi(callee_codeinst).def
+    argtypes = Compiler.va_process_argtypes(Compiler.optimizer_lattice(interp), argtypes, UInt(m.nargs), m.isva)
+    mapping = CalleeMapping(Compiler.optimizer_lattice(interp), argtypes, callee_result, callee_codeinst.inferred.ir.argtypes)
     new_rt = apply_linear_incidence(Compiler.optimizer_lattice(interp), callee_result.extended_rt,
         CallerMappingState(callee_result, interp.var_to_diff, interp.varclassification, interp.varkinds, VarEqClassification[]), mapping)
 
@@ -164,7 +166,7 @@ function tfunc(F::Union{Val{Core.Intrinsics.sub_float}, Val{Core.Intrinsics.sub_
     return Incidence(const_val, rrow)
 end
 
-function tfunc(::Val{Core.Intrinsics.mul_float}, @nospecialize(a::Union{Const, Type{Float64}, Incidence}), @nospecialize(b::Union{Const, Type{Float64}, Incidence}))
+function tfunc(::Union{Val{Core.Intrinsics.mul_float}, Val{Core.Intrinsics.mul_int}}, @nospecialize(a::Union{Const, Type{Float64}, Incidence}), @nospecialize(b::Union{Const, Type{Float64}, Incidence}))
     if a === Float64 || b === Float64
         return Float64
     end
@@ -341,7 +343,7 @@ is_any_incidence(@nospecialize args...) = any(@nospecialize(x)->isa(x, Incidence
         if is_any_incidence(a)
             if f == Core.Intrinsics.neg_float || f === Core.Intrinsics.neg_int
                 return tfunc(Val(f), a)
-            elseif f === Core.Intrinsics.ctlz_int || f === Core.Intrinsics.not_int || f === Core.Intrinsics.abs_float
+            elseif f === Core.Intrinsics.ctlz_int || f === Core.Intrinsics.not_int || f === Core.Intrinsics.abs_float || f === Core.Intrinsics.rint_llvm
                 return generic_math_onearg(f, a)
             end
         end
@@ -351,7 +353,7 @@ is_any_incidence(@nospecialize args...) = any(@nospecialize(x)->isa(x, Incidence
         if is_any_incidence(a, b)
             if (f == Core.Intrinsics.add_float || f == Core.Intrinsics.sub_float) ||
                 (f == Core.Intrinsics.add_int || f == Core.Intrinsics.sub_int) ||
-                (f == Core.Intrinsics.mul_float || f == Core.Intrinsics.div_float) ||
+                (f == Core.Intrinsics.mul_float || f == Core.Intrinsics.div_float || f == Core.Intrinsics.mul_int) ||
                 f == Core.Intrinsics.copysign_float
                 return tfunc(Val(f), a, b)
             elseif f in (Core.Intrinsics.or_int, Core.Intrinsics.and_int, Core.Intrinsics.xor_int,

--- a/src/analysis/structural.jl
+++ b/src/analysis/structural.jl
@@ -46,10 +46,10 @@ function _structural_analysis!(ci::CodeInstance, world::UInt)
 
     # Equations
     eqclassification = VarEqClassification[]
-    eqssas = Pair{Union{SSAValue, Argument}, Vector{SSAValue}}[]
+    eqssas = Union{SSAValue, Argument}[]
     eqkinds = Intrinsics.EqKind[]
     function add_equation!(i::Union{SSAValue, Argument})
-        push!(eqssas, i=>SSAValue[])
+        push!(eqssas, i)
         push!(eqclassification, isa(i, Argument) ? External : Owned)
         push!(eqkinds, Intrinsics.RemovedEq)
         return length(eqssas)
@@ -65,14 +65,19 @@ function _structural_analysis!(ci::CodeInstance, world::UInt)
     # Get the IR
     ir = copy(ci.inferred.ir)
 
+    compact = IncrementalCompact(ir)
+    old_argtypes = copy(ir.argtypes)
+    empty!(ir.argtypes)
+    (arg_replacements, new_argtypes, nexternalargvars) = flatten_arguments!(compact, old_argtypes, 0, ir.argtypes)
+    for i = 1:nexternalargvars
+        add_variable!(Argument(i))
+    end
+    argtypes = Any[Incidence(new_argtypes[i], i) for i = 1:nexternalargvars]
+
     # Allocate variable and equation numbers of any incoming arguments
     refiner = StructuralRefiner(world, var_to_diff, varkinds, varclassification)
-    argtypes = Any[make_argument_lattice_elem(Compiler.typeinf_lattice(refiner), Argument(i), argt, add_variable!, add_equation!, add_scope!) for (i, argt) in enumerate(ir.argtypes)]
     nexternalargvars = length(var_to_diff)
     nexternaleqs = length(eqssas)
-
-    # (::equation)(...) calls
-    eqcallssas = SSAValue[]
 
     # IR Warnings - this tracks cases of malformed optional information. The system
     # is still malformed, but something is likely wrong. These will get printed if
@@ -82,32 +87,39 @@ function _structural_analysis!(ci::CodeInstance, world::UInt)
     # Go through the IR, annotating each intrinsic with an appropriate taint
     # source lattice element.
     externally_refined = BitSet()
-    for (bb, i) in bbidxiter(ir)
-        stmt = ir.stmts[i][:inst]
+    for ((old_idx, i), stmt) in compact
+        urs = userefs(stmt)
+        compact[SSAValue(i)] = nothing
+        for ur in urs
+            if isa(ur[], Argument)
+                repl = arg_replacements[ur[].n]
+                ur[] = repl
+            end
+        end
+        stmt = urs[]
+        compact[SSAValue(i)] = stmt
         if isexpr(stmt, :invoke)
-            if is_known_invoke(stmt, variable, ir)
+            if is_known_invoke(stmt, variable, compact)
                 v = add_variable!(SSAValue(i))
-                ir.stmts[i][:type] = Incidence(v)
+                compact[SSAValue(i)][:type] = Incidence(v)
                 push!(externally_refined, i)
-            elseif is_known_invoke(stmt, equation, ir)
-                ir.stmts[i][:type] = Eq(add_equation!(SSAValue(i)))
+            elseif is_known_invoke(stmt, equation, compact)
+                compact[SSAValue(i)][:type] = Eq(add_equation!(SSAValue(i)))
                 push!(externally_refined, i)
-            elseif is_known_invoke(stmt, sim_time, ir)
-                ir.stmts[i][:type] = Incidence(0)
+            elseif is_known_invoke(stmt, sim_time, compact)
+                compact[SSAValue(i)][:type] = Incidence(0)
                 push!(externally_refined, i)
-            elseif is_equation_call(stmt, ir, #=allow_call=#false)
-                push!(eqcallssas, SSAValue(i))
             else
-                ir.stmts[i][:flag] |= Compiler.IR_FLAG_REFINED
+                compact[SSAValue(i)][:flag] |= Compiler.IR_FLAG_REFINED
             end
         elseif isexpr(stmt, :call)
-            if is_known_call(stmt, Core.current_scope, ir)
+            if is_known_call(stmt, Core.current_scope, compact)
                 # N.B.: We make the assumption here that all current_scope that
                 # was inside EnterScope within the same function has already
                 # been folded by SROA, so the only thing left are those that
                 # refer to the function's entry scope.
-                ir.stmts[i][:type] = cur_scope_lattice
-                ir.stmts[i][:flag] |= Compiler.IR_FLAG_REFINED
+                compact[SSAValue(i)][:type] = cur_scope_lattice
+                compact[SSAValue(i)][:flag] |= Compiler.IR_FLAG_REFINED
                 push!(externally_refined, i)
                 continue
             end
@@ -123,23 +135,23 @@ function _structural_analysis!(ci::CodeInstance, world::UInt)
         elseif isa(stmt, GlobalRef)
             continue
         elseif isexpr(stmt, :new)
-            newT = argextype(stmt.args[1], ir)
+            newT = argextype(stmt.args[1], compact)
             if isa(newT, Const) && newT.val === Intrinsics.ScopeIdentity
                 # Allocate the identity now. After inlining, we're guaranteed that
                 # every Expr(:new) uniquely corresponds to a scope identity, so this
                 # is legal here (bug not before)
-                ir.stmts[i][:stmt] = Intrinsics.ScopeIdentity()
-                ir.stmts[i][:flag] |= CC.IR_FLAG_REFINED
+                compact[SSAValue(i)][:stmt] = Intrinsics.ScopeIdentity()
+                compact[SSAValue(i)][:flag] |= CC.IR_FLAG_REFINED
             end
             continue
         elseif isexpr(stmt, :splatnew)
             continue
         elseif isexpr(stmt, :boundscheck)
-            ir.stmts[i][:type] = Incidence(Bool)
-            ir.stmts[i][:flag] |= Compiler.IR_FLAG_REFINED
+            compact[SSAValue(i)][:type] = Incidence(Bool)
+            compact[SSAValue(i)][:flag] |= Compiler.IR_FLAG_REFINED
         elseif isa(stmt, PhiNode)
             # Take into account control-dependent taint
-            ir.stmts[i][:flag] |= Compiler.IR_FLAG_REFINED
+            compact[SSAValue(i)][:flag] |= Compiler.IR_FLAG_REFINED
         elseif isa(stmt, PiNode)
             continue
         elseif isa(stmt, GotoIfNot) || isa(stmt, GotoNode)
@@ -150,6 +162,7 @@ function _structural_analysis!(ci::CodeInstance, world::UInt)
             @show stmt
         end
     end
+    ir = Compiler.finish(compact)
 
     # Perform the actual dataflow analysis
     mi = Compiler.get_ci_mi(ci)
@@ -207,7 +220,7 @@ function _structural_analysis!(ci::CodeInstance, world::UInt)
     end
 
     # Do the same for equations
-    for (ieq, (ssa, _)) in enumerate(eqssas)
+    for (ieq, ssa) in enumerate(eqssas)
         inst = ir[ssa][:inst]::Union{Nothing, Expr}
         inst === nothing && continue # equation unused and was deleted
         @assert is_known_invoke(inst, equation, ir)
@@ -241,61 +254,61 @@ function _structural_analysis!(ci::CodeInstance, world::UInt)
 
     # Now record the association of (::equation)() calls with the equations that they originate from
     total_incidence = Vector{Any}(undef, length(eqssas))
-    for ssa in eqcallssas
-        eqcall = ir[ssa][:inst]
-        eqcall === nothing && continue # equation call was on a dead branch - deleted
-        eqeq = argextype(eqcall.args[2], ir)
 
-        if !isa(eqeq, Eq)
-            return UncompilableIPOResult(warnings, UnsupportedIRException("Equation call at $ssa has unknown equation reference.", ir))
-        end
-        ieq = eqeq.id
+    # Now go through and incorporate the structural information from any interior calls
+    eq_callee_mapping = Vector{Union{Nothing, Vector{Pair{StructuralSSARef, Int}}}}(nothing, length(eqssas))
+    handler_info = Compiler.compute_trycatch(ir)
+    ncallees = 0
+    compact = IncrementalCompact(ir)
+    for ((old_idx, i), stmt) in compact
+        stmt === nothing && continue
+        # No need to process error paths - even if they were to contain intrinsics, such intrinsics would have
+        # no effect.
+        compact[SSAValue(i)][:type] === Union{} && continue
+        isexpr(stmt, :invoke) || continue
+        is_known_invoke(stmt, variable, compact) && continue
+        is_known_invoke(stmt, equation, compact) && continue
+        is_known_invoke(stmt, sim_time, compact) && continue
+        is_known_invoke(stmt, ddt, compact) && continue
+        if is_equation_call(stmt, compact)
+            eqeq = argextype(stmt.args[2], compact)
 
-        eqssaval = eqcall.args[3]
-        if !isa(eqssaval, SSAValue) && !isa(eqssaval, Argument)
-            if !iszero(eqssaval)
-                return UncompilableIPOResult(warnings, UnsupportedIRException(
-                    "Equation call for $ieq at $ssa is set to $eqssaval. The system is unsolvable.", ir))
+            if !isa(eqeq, Eq)
+                return UncompilableIPOResult(warnings, UnsupportedIRException("Equation call at $ssa has unknown equation reference.", ir))
+            end
+            ieq = eqeq.id
+
+            eqssaval = stmt.args[3]
+            if !isa(eqssaval, SSAValue) && !isa(eqssaval, Argument)
+                if !iszero(eqssaval)
+                    return UncompilableIPOResult(warnings, UnsupportedIRException(
+                        "Equation call for $ieq at $ssa is set to $eqssaval. The system is unsolvable.", ir))
+                end
+                continue
+            end
+
+            inc = argextype(eqssaval, compact)
+            if !isa(inc, Incidence)
+                return UncompilableIPOResult(warnings, UnsupportedIRException("Expected incidence analysis to produce result for $eqssaval, got $inc", ir))
+            end
+            if isassigned(total_incidence, ieq)
+                total_incidence[ieq] += inc
+            else
+                total_incidence[ieq] = inc
             end
             continue
         end
 
-        inc = argextype(eqssaval, ir)
-        if !isa(inc, Incidence)
-            return UncompilableIPOResult(warnings, UnsupportedIRException("Expected incidence analysis to produce result for $eqssaval, got $inc", ir))
-        end
-        if isassigned(total_incidence, ieq)
-            total_incidence[ieq] += inc
-        else
-            total_incidence[ieq] = inc
-        end
-
-        push!(eqssas[ieq][2], ssa)
-    end
-
-    # Now go through and incorporate the structural information from any interior calls
-    eq_callee_mapping = Vector{Union{Nothing, Vector{Pair{SSAValue, Int}}}}(nothing, length(eqssas))
-    handler_info = Compiler.compute_trycatch(ir)
-    ncallees = 0
-    for i = 1:length(ir.stmts)
-        inst = ir[SSAValue(i)]
-        stmt = inst[:stmt]
-        stmt === nothing && continue
-        # No need to process error paths - even if they were to contain intrinsics, such intrinsics would have
-        # no effect.
-        inst[:type] === Union{} && continue
-        isexpr(stmt, :invoke) || continue
-        is_known_invoke(stmt, variable, ir) && continue
-        is_known_invoke(stmt, equation, ir) && continue
-        is_known_invoke(stmt, sim_time, ir) && continue
-        is_known_invoke(stmt, ddt, ir) && continue
-        is_equation_call(stmt, ir) && continue
+        inst = compact[SSAValue(i)]
+        stmtype = inst[:type]
+        stmtflags = inst[:flag]
+        line = inst[:line]
 
         info = inst[:info]
+        callee_codeinst = stmt.args[1]
         if isa(info, MappingInfo)
             (; result, mapping) = info
         else
-            callee_codeinst = stmt.args[1]
             result = structural_analysis!(callee_codeinst, Compiler.get_inference_world(refiner))
 
             if isa(result, UncompilableIPOResult)
@@ -303,17 +316,38 @@ function _structural_analysis!(ci::CodeInstance, world::UInt)
                 return result
             end
 
-            callee_argtypes = Compiler.collect_argtypes(refiner, stmt.args, Compiler.StatementState(nothing, false), irsv)[2:end]
-            mapping = CalleeMapping(Compiler.optimizer_lattice(refiner), callee_argtypes, result)
-            inst[:info] = MappingInfo(info, result, mapping)
+            callee_argtypes = Any[argextype(stmt.args[i], compact) for i in 2:length(stmt.args)]
+            mapping = CalleeMapping(Compiler.optimizer_lattice(refiner), callee_argtypes, result, callee_codeinst.inferred.ir.argtypes)
+            inst[:info] = info = MappingInfo(info, result, mapping)
         end
 
-        err = add_internal_equations_to_structure!(refiner, eqkinds, eqclassification, total_incidence, eq_callee_mapping, SSAValue(i),
+        # Determine whether this call is eligible for opaque treatement
+        if isa(result.extended_rt, Incidence) && isempty(result.total_incidence)
+            # For now, turn this into a call.
+            # TODO: We should keep the native code instance and use that
+            # TODO: Additional conditions:
+            #  - Does not introduce new variables
+            compact[SSAValue(i)] = nothing
+            compact[SSAValue(i)] = Expr(:call, stmt.args[2:end]...)
+            continue
+        end
+
+        # Rewrite to flattened ABI
+        compact[SSAValue(i)] = nothing
+        compact.result_idx -= 1
+        new_args = _flatten_parameter!(Compiler.optimizer_lattice(refiner), compact, callee_codeinst.inferred.ir.argtypes, arg->stmt.args[arg+1], line)
+
+        new_call = insert_node_here!(compact,
+                NewInstruction(Expr(:invoke, (StructuralSSARef(compact.result_idx), callee_codeinst), new_args...), stmtype, info, line, stmtflags))
+        compact.ssa_rename[compact.idx - 1] = new_call
+
+        err = add_internal_equations_to_structure!(refiner, eqkinds, eqclassification, total_incidence, eq_callee_mapping, StructuralSSARef(new_call.id),
             result, mapping)
         if err !== true
             return UncompilableIPOResult(warnings, UnsupportedIRException(err, ir))
         end
     end
+    ir = Compiler.finish(compact)
 
     nimplicitoutpairs = 0
     var_to_diff = StateSelection.complete(var_to_diff)
@@ -382,7 +416,7 @@ function process_ipo_return!(𝕃, ultimate_rt::Incidence, eqclassification, eqk
 end
 
 function add_internal_equations_to_structure!(refiner::StructuralRefiner, eqkinds::Vector{Intrinsics.EqKind}, eqclassification::Vector{VarEqClassification}, total_incidence,
-        eq_callee_mapping::Vector{Union{Nothing, Vector{Pair{SSAValue, Int}}}}, thisssa::SSAValue, callee_result::DAEIPOResult, callee_mapping::CalleeMapping)
+        eq_callee_mapping::Vector{Union{Nothing, Vector{Pair{StructuralSSARef, Int}}}}, thisssa::StructuralSSARef, callee_result::DAEIPOResult, callee_mapping::CalleeMapping)
     cms = CallerMappingState(callee_result, refiner.var_to_diff, refiner.varclassification, refiner.varkinds, eqclassification)
     for i in 1:length(callee_mapping.var_coeffs)
         if !isassigned(callee_mapping.var_coeffs, i)

--- a/src/analysis/utils.jl
+++ b/src/analysis/utils.jl
@@ -1,5 +1,6 @@
 function is_known_invoke(@nospecialize(x), @nospecialize(func), ir::Union{IRCode,IncrementalCompact})
     isexpr(x, :invoke) || return false
+    length(x.args) <= 1 && return false
     ft = argextype(x.args[2], ir)
     return singleton_type(ft) === func
 end
@@ -7,6 +8,7 @@ end
 function is_equation_call(@nospecialize(x), ir::Union{IRCode,IncrementalCompact},
         allow_call::Bool=true)
     isexpr(x, :invoke) || (allow_call && isexpr(x, :call)) || return false
+    isexpr(x, :invoke) && length(x.args) <= 1 && return false
     ft = argextype(_eq_function_arg(x), ir)
     return widenconst(ft) === equation
 end

--- a/src/transform/codegen/init_uncompress.jl
+++ b/src/transform/codegen/init_uncompress.jl
@@ -149,6 +149,7 @@ function gen_init_uncompress!(
             insert_node!(ir, idx, ni)
         end
         ir = Compiler.compact!(ir)
+        Compiler.verify_ir(ir)
 
         widen_extra_info!(ir)
         src = ir_to_src(ir)

--- a/test/ipo.jl
+++ b/test/ipo.jl
@@ -47,6 +47,30 @@ for (sol, i) in Iterators.product((dae_sol, ode_sol), 1:2)
     @test all(map((x,y)->isapprox(x[], y, atol=1e-2), sol[i, :], 2*acot.(exp.(-sol.t).*cot(1/2))))
 end
 
+#============== NonLinear argument ============#
+@noinline sink!(x, v) = always!(x - v)
+function sinsink!()
+    x = continuous()
+    sink!(ddt(x), sin(x))
+end
+dae_sol = solve(DAECProblem(sinsink!, (1,) .=> 1.), IDA())
+ode_sol = solve(ODECProblem(sinsink!, (1,) .=> 1.), Rodas5(autodiff=false))
+for sol in (dae_sol, ode_sol)
+    @test all(map((x,y)->isapprox(x[], y, atol=1e-2), sol[1, :], 2*acot.(exp.(-sol.t).*cot(1/2))))
+end
+
+#============== NonLinear argument + derivative ============#
+@noinline sink2!(x, v) = always!(ddt(x) - v)
+function sinsink2!()
+    x = continuous()
+    sink2!(x, sin(x))
+end
+dae_sol = solve(DAECProblem(sinsink2!, (1,) .=> 1.), IDA())
+ode_sol = solve(ODECProblem(sinsink2!, (1,) .=> 1.), Rodas5(autodiff=false))
+for sol in (dae_sol, ode_sol)
+    @test all(map((x,y)->isapprox(x[], y, atol=1e-2), sol[1, :], 2*acot.(exp.(-sol.t).*cot(1/2))))
+end
+
 #============== SICM ============#
 struct sicm!
     arg::Float64


### PR DESCRIPTION
As discussed on Slack, this augments structural analysis to flatten argument lists when function have nested argument structures. The primary motivation is to make it easier to track non-linear expressions used as IPO arguments (see newly added tests).