### PR TITLE
Add `@sshow` helper to avoid task switches

### DIFF
--- a/src/analysis/ADAnalyzer.jl
+++ b/src/analysis/ADAnalyzer.jl
@@ -47,8 +47,8 @@ end
         return false
     end
     if isa(src, Compiler.OptimizationState)
-        @show src.linfo
-        @show src.src
+        @sshow src.linfo
+        @sshow src.src
         error()
     end
     if isa(src, AnalyzedSource)

--- a/src/analysis/structural.jl
+++ b/src/analysis/structural.jl
@@ -159,7 +159,7 @@ function _structural_analysis!(ci::CodeInstance, world::UInt)
         elseif stmt === nothing
             continue
         else
-            @show stmt
+            @sshow stmt
         end
     end
     ir = Compiler.finish(compact)

--- a/src/transform/codegen/init_uncompress.jl
+++ b/src/transform/codegen/init_uncompress.jl
@@ -120,7 +120,7 @@ function gen_init_uncompress!(
 
             if is_known_invoke(stmt, variable, ir) || is_equation_call(stmt, ir)
                 display(ir)
-                @show stmt
+                @sshow stmt
                 error()
             elseif is_known_invoke(stmt, equation, ir)
                 # Equation - used, but only as an arg to equation call, which will all get

--- a/src/transform/codegen/rhs.jl
+++ b/src/transform/codegen/rhs.jl
@@ -187,7 +187,7 @@ function rhs_finish!(
                 assgn = var_assignment[varnum]
                 if assgn == nothing
                     display(StateSelection.MatchedSystemStructure(structure, var_eq_matching))
-                    @show varnum
+                    @sshow varnum
                     error("Variable left over in IR that doesn't have an assignment")
                 end
                 (kind, slot) = assgn

--- a/src/transform/tearing/schedule.jl
+++ b/src/transform/tearing/schedule.jl
@@ -794,10 +794,10 @@ function tearing_schedule!(state::TransformationState, ci::CodeInstance, key::To
                             cstructure = make_structure_from_ipo(callee_result)
                             cvar_eq_matching = matching_for_key(callee_result, callee_key, cstructure)
                             display(StateSelection.MatchedSystemStructure(cstructure, cvar_eq_matching))
-                            @show eq_orders
-                            @show callee_result.total_incidence[callee_eq]
-                            @show total_incidence[caller_eq]
-                            @show callee_var_schedule
+                            @sshow eq_orders
+                            @sshow callee_result.total_incidence[callee_eq]
+                            @sshow total_incidence[caller_eq]
+                            @sshow callee_var_schedule
                             error("Caller Equation $(caller_eq) (callee equation $(callee_eq)) is not in the callee schedule ($sref)")
                         end
                     end
@@ -867,7 +867,7 @@ function tearing_schedule!(state::TransformationState, ci::CodeInstance, key::To
                 # TODO: Pull this up, if arguments are state-independent
                 continue
             else
-                @show stmt
+                @sshow stmt
                 error()
             end
         else
@@ -952,9 +952,9 @@ function tearing_schedule!(state::TransformationState, ci::CodeInstance, key::To
                 error()
             else
                 if !(lin_var in key.diff_states || lin_var in key.alg_states)
-                    @show lin_var
-                    @show ordinal
-                    @show eq_order
+                    @sshow lin_var
+                    @sshow ordinal
+                    @sshow eq_order
                     display(result.ir)
                     error("Tried to schedule variable $(lin_var) that we do not have a solution to (but our scheduling should have ensured that we do)")
                 end


### PR DESCRIPTION
Just like `@show`, but directly writes to C stdout with `Core.println` instead of `Base.println`.

I didn't write tests for it because AFAIK there is no way to not have it pollute `stdout` in the same process during testing. However I tested it on the REPL to make sure it is working as intended.