### PR TITLE
Annotate use by callees in `MatchedSystemStructure`

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1927,7 +1927,6 @@ weakdeps = ["SparseArrays", "StaticArraysCore"]
 [[deps.SciMLSensitivity]]
 deps = ["ADTypes", "Accessors", "Adapt", "ArrayInterface", "ChainRulesCore", "DiffEqBase", "DiffEqCallbacks", "DiffEqNoiseProcess", "Distributions", "FastBroadcast", "FiniteDiff", "ForwardDiff", "FunctionProperties", "FunctionWrappersWrappers", "Functors", "GPUArraysCore", "LinearAlgebra", "LinearSolve", "Markdown", "OrdinaryDiffEqCore", "PreallocationTools", "QuadGK", "Random", "RandomNumbers", "RecursiveArrayTools", "Reexport", "ReverseDiff", "SciMLBase", "SciMLJacobianOperators", "SciMLOperators", "SciMLStructures", "StaticArrays", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "Tracker", "Zygote"]
 git-tree-sha1 = "a8a6e5e1bfb889c392d67245911fd4e1ad0ba562"
-path = "/home/keno/.julia/dev/SciMLSensitivity"
 repo-rev = "kf/mindep4"
 repo-url = "https://github.com/CedarEDA/SciMLSensitivity.jl"
 uuid = "1ed8b502-d754-442c-8d5d-10ac956f44a1"
@@ -2040,9 +2039,9 @@ weakdeps = ["ChainRulesCore"]
 
 [[deps.StateSelection]]
 deps = ["DocStringExtensions", "FindFirstFunctions", "Graphs", "LinearAlgebra", "Setfield", "SparseArrays", "UnPack"]
-git-tree-sha1 = "bdb37d184a0a529c307875a6bc066f561e0c25f6"
-repo-rev = "main"
-repo-url = "https://github.com/JuliaComputing/StateSelection.jl.git"
+git-tree-sha1 = "b767bdaf84d6d0f3b8b9568ff6e4e3d53a6bcad4"
+repo-rev = "add-ssa-uses"
+repo-url = "https://github.com/serenity4/StateSelection.jl"
 uuid = "64909d44-ed92-46a8-bbd9-f047dfbdc84b"
 version = "0.2.1"
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2039,9 +2039,9 @@ weakdeps = ["ChainRulesCore"]
 
 [[deps.StateSelection]]
 deps = ["DocStringExtensions", "FindFirstFunctions", "Graphs", "LinearAlgebra", "Setfield", "SparseArrays", "UnPack"]
-git-tree-sha1 = "b767bdaf84d6d0f3b8b9568ff6e4e3d53a6bcad4"
-repo-rev = "add-ssa-uses"
-repo-url = "https://github.com/serenity4/StateSelection.jl"
+git-tree-sha1 = "e77065f876d178339a04947200593b12122724f0"
+repo-rev = "main"
+repo-url = "https://github.com/JuliaComputing/StateSelection.jl"
 uuid = "64909d44-ed92-46a8-bbd9-f047dfbdc84b"
 version = "0.2.1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -50,7 +50,7 @@ Cthulhu = {rev = "master", url = "https://github.com/JuliaDebug/Cthulhu.jl.git"}
 DifferentiationInterface = {rev = "main", subdir = "DifferentiationInterface", url = "https://github.com/Keno/DifferentiationInterface.jl"}
 Diffractor = {rev = "main", url = "https://github.com/JuliaDiff/Diffractor.jl.git"}
 SimpleNonlinearSolve = {rev = "master", subdir = "lib/SimpleNonlinearSolve", url = "https://github.com/SciML/NonlinearSolve.jl.git"}
-StateSelection = {rev = "main", url = "https://github.com/JuliaComputing/StateSelection.jl.git"}
+StateSelection = {rev = "add-ssa-uses", url = "https://github.com/serenity4/StateSelection.jl"}
 
 [compat]
 Accessors = "0.1.36"

--- a/Project.toml
+++ b/Project.toml
@@ -50,7 +50,7 @@ Cthulhu = {rev = "master", url = "https://github.com/JuliaDebug/Cthulhu.jl.git"}
 DifferentiationInterface = {rev = "main", subdir = "DifferentiationInterface", url = "https://github.com/Keno/DifferentiationInterface.jl"}
 Diffractor = {rev = "main", url = "https://github.com/JuliaDiff/Diffractor.jl.git"}
 SimpleNonlinearSolve = {rev = "master", subdir = "lib/SimpleNonlinearSolve", url = "https://github.com/SciML/NonlinearSolve.jl.git"}
-StateSelection = {rev = "add-ssa-uses", url = "https://github.com/serenity4/StateSelection.jl"}
+StateSelection = {rev = "main", url = "https://github.com/JuliaComputing/StateSelection.jl"}
 
 [compat]
 Accessors = "0.1.36"

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -45,8 +45,7 @@ function code_structure_by_type(@nospecialize(tt::Type); world::UInt = Base.tls_
   (diff_key, init_key) = ret
   key = in(mode, (DAE, DAENoInit, ODE, ODENoInit)) ? diff_key : init_key
 
-  # Removing `@invokelatest` segfaults in LLVM with "Unexpected instruction".
-  var_eq_matching = @invokelatest matching_for_key(tstate, key)
+  var_eq_matching = matching_for_key(tstate, key)
   return StateSelection.MatchedSystemStructure(result, structure, var_eq_matching)
 end
 

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -65,7 +65,7 @@ Parameters:
 - `world::UInt = Base.get_world_counter()`: the world in which to operate.
 - `force_inline_all::Bool = false`: if `true`, make inlining heuristics choose to always inline where possible.
 - `result::Bool = false`: if `true`, return the full [`DAEIPOResult`](@ref) instead of just the `IRCode`.
-- `matched::Bool = false`: if `true`, return the [`MatchedSystemStructure`](@ref) after top-level state selection
+- `matched::Bool = false`: if `true`, return the `MatchedSystemStructure` after top-level state selection
   for visualization purposes.
 - `mode::GenerationMode = DAE`: specifies the generation mode to use for the compilation pipeline. Only used when `matched` is `true`.
 

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -68,6 +68,7 @@ Parameters:
 - `result::Bool = false`: if `true`, return the full [`DAEIPOResult`](@ref) instead of just the `IRCode`.
 - `matched::Bool = false`: if `true`, return the [`MatchedSystemStructure`](@ref) after top-level state selection
   for visualization purposes.
+- `mode::GenerationMode = DAE`: specifies the generation mode to use for the compilation pipeline. Only used when `matched` is `true`.
 
 !!! warning
     This will cache analysis results. You might want to invalidate with `DAECompiler.refresh()` between calls to `@code_structure`.

--- a/src/transform/codegen/rhs.jl
+++ b/src/transform/codegen/rhs.jl
@@ -187,7 +187,7 @@ function rhs_finish!(
 
                 assgn = var_assignment[varnum]
                 if assgn == nothing
-                    display(StateSelection.MatchedSystemStructure(structure, var_eq_matching))
+                    display(StateSelection.MatchedSystemStructure(result, structure, var_eq_matching))
                     @sshow varnum
                     error("Variable left over in IR that doesn't have an assignment")
                 end

--- a/src/transform/state_selection.jl
+++ b/src/transform/state_selection.jl
@@ -149,6 +149,22 @@ StateSelection.BipartiteGraphs.overview_label(::Type{WrongEquation}) = ('✕', "
 const IPOMatches = Union{Unassigned, SelectedState, StateInvariant, AlgebraicState, FullyLinear, WrongEquation, InOut}
 const IPOMatching = StateSelection.Matching{IPOMatches}
 
+struct CalleeInfo
+    callees::Union{Nothing, Vector{StructuralSSARef}}
+end
+CalleeInfo(callee::StructuralSSARef) = CalleeInfo([callee])
+StateSelection.BipartiteGraphs.overview_label(::Type{CalleeInfo}) = ('%', "Used in callee (referenced by structural SSA)", 178)
+
+function Base.show(io::IO, (; callees)::CalleeInfo)
+    callees === nothing && return
+    first = true
+    for callee in callees
+        !first && print(io, ", ")
+        printstyled(io, "%", callee.id; color = 178)
+        first = false
+    end
+end
+
 function top_level_state_selection!(tstate)
     (; result, structure) = tstate
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -5,6 +5,8 @@ using DAECompiler
 using DAECompiler.Intrinsics
 using Compiler: IRCode
 
+@noinline callee!(x, y) = always!(x + y)
+
 function ssrm()
     x₁ = continuous()
     x₂ = continuous()
@@ -20,7 +22,7 @@ function ssrm()
     always!((ẍ₁+ẍ₂)-(ẋ₁+ẋ₂)+x₄)
     always!((ẍ₁+ẍ₂)+x₃)
     always!(x₂+ẍ₃+ẋ₄)
-    always!(x₃+ẋ₄)
+    callee!(x₃,ẋ₄)
 end
 
 ir = code_structure_by_type(Tuple{typeof(ssrm)})
@@ -33,5 +35,8 @@ ir = @code_structure world = Base.get_world_counter() ssrm()
 @test isa(ir, IRCode)
 result = @code_structure result = true ssrm()
 @test isa(result, DAECompiler.DAEIPOResult)
+result = @code_structure matched = true ssrm()
+@test isa(result, DAECompiler.MatchedSystemStructure)
+@test contains(sprint(show, result), r"%\d+")
 
 end # module

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -36,7 +36,7 @@ ir = @code_structure world = Base.get_world_counter() ssrm()
 result = @code_structure result = true ssrm()
 @test isa(result, DAECompiler.DAEIPOResult)
 result = @code_structure matched = true ssrm()
-@test isa(result, DAECompiler.MatchedSystemStructure)
+@test isa(result, DAECompiler.StateSelection.MatchedSystemStructure)
 @test contains(sprint(show, result), r"%\d+")
 
 end # module


### PR DESCRIPTION
Implements the remaining feature for #37, mapping equations/variables to callees that use them. Requires https://github.com/JuliaComputing/StateSelection.jl/pull/3.

Before merge:
- [x] Remove StateSelection PR from project & manifest once merged.

Here is what it looks like:
![screenshot](https://github.com/user-attachments/assets/adf24e4a-aae3-4075-80d5-a63d3666338e)

I also added a `matched = true` parameter to `@code_structure` so we can easily get to this visualization.
